### PR TITLE
qgis debian repo gpg key changed

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -15,7 +15,7 @@ class qgis::repo {
       location    => 'http://qgis.org/debian',
       release     => $::lsbdistcodename,
       repos       => 'main',
-      key         => '47765B75',
+      key         => 'CAEB3DC3BDF7FB45',
       key_server  => 'keyserver.ubuntu.com',
       include_src => true,
     }


### PR DESCRIPTION
Repo key has changed, modifications made in the module based on qgis documentation (https://qgis.org/en/site/forusers/alldownloads.html#debian-ubuntu)